### PR TITLE
fixes empty and duplicate category creation

### DIFF
--- a/popup/src/components/Note.jsx
+++ b/popup/src/components/Note.jsx
@@ -26,12 +26,24 @@ export default function Note({ snipd }) {
   };
 
   const addCategory = (newCategory) => {
-      chrome.storage.local.get(["snipd_categories"]).then(obj => {
-          const new_category_list = [...obj.snipd_categories, newCategory];
-          chrome.storage.local.set({snipd_categories: new_category_list}).then(() => {
-              populateCategory(newCategory);
-          });
+    if (!newCategory.trim()) {
+      console.error("Category cannot be empty");
+      return;
+    }
+
+    chrome.storage.local.get(["snipd_categories"]).then((obj) => {
+      const existingCategories = obj.snipd_categories || [];
+
+      if (existingCategories.includes(newCategory)) {
+        console.error("Category already exists");
+        return;
+      }
+
+      const new_category_list = [...existingCategories, newCategory];
+      chrome.storage.local.set({ snipd_categories: new_category_list }).then(() => {
+        populateCategory(newCategory);
       });
+    });
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
For now, it console logs the error. I'll create a new issue to show the alert as text inside the popup only